### PR TITLE
Restructure more similar to workshops.

### DIFF
--- a/StreamingAppDemo/app/src/main/AndroidManifest.xml
+++ b/StreamingAppDemo/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools" package="com.fortyseven.degrees.streamingapp">
 
     <application
-        android:name=".StreamApp"
+        android:name=".app.StreamApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -12,7 +12,7 @@
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
 
-        <activity android:name=".MainActivity">
+        <activity android:name=".main.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/RxViewModel.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/RxViewModel.kt
@@ -13,7 +13,6 @@ interface RxViewModel<A> {
     fun isEmpty(): Observable<Boolean>
     fun isNotEmpty(): Observable<Boolean> =
         isEmpty().map(Boolean::not)
-
 }
 
 fun <A> RxViewModel(lifecycle: LifecycleOwner, default: A? = null): RxViewModel<A> =

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/algebra.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/algebra.kt
@@ -1,0 +1,35 @@
+package com.fortyseven.degrees.streamingapp
+
+import io.reactivex.Observable
+import memeid.UUID
+
+data class User(val id: UUID, val name: String) {
+    companion object
+}
+
+interface AccountRepo {
+    fun fetchAccounts(): Observable<List<User>>
+}
+
+interface AccountPersistence {
+    fun loadAccountsFromDatabase(): Observable<List<User>>
+}
+
+interface HomeInteractions {
+    fun pullToRefresh(): Observable<Unit>
+}
+
+interface HomeDependency : HomeInteractions, AccountRepo, AccountPersistence, RxViewModel<HomeVM> {
+    companion object {
+        fun create(
+            interactions: HomeInteractions,
+            repo: AccountRepo,
+            persistence: AccountPersistence,
+            viewModel: RxViewModel<HomeVM>
+        ): HomeDependency = object : HomeDependency,
+            HomeInteractions by interactions,
+            AccountRepo by repo,
+            AccountPersistence by persistence,
+            RxViewModel<HomeVM> by viewModel {}
+    }
+}

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/algebra.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/algebra.kt
@@ -19,17 +19,17 @@ interface HomeInteractions {
     fun pullToRefresh(): Observable<Unit>
 }
 
-interface HomeDependency : HomeInteractions, AccountRepo, AccountPersistence, RxViewModel<HomeVM> {
+interface HomeDependencies : HomeInteractions, AccountRepo, AccountPersistence, RxViewModel<HomeViewState> {
     companion object {
         fun create(
             interactions: HomeInteractions,
             repo: AccountRepo,
             persistence: AccountPersistence,
-            viewModel: RxViewModel<HomeVM>
-        ): HomeDependency = object : HomeDependency,
+            viewModel: RxViewModel<HomeViewState>
+        ): HomeDependencies = object : HomeDependencies,
             HomeInteractions by interactions,
             AccountRepo by repo,
             AccountPersistence by persistence,
-            RxViewModel<HomeVM> by viewModel {}
+            RxViewModel<HomeViewState> by viewModel {}
     }
 }

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/app/StreamApp.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/app/StreamApp.kt
@@ -1,4 +1,4 @@
-package com.fortyseven.degrees.streamingapp
+package com.fortyseven.degrees.streamingapp.app
 
 import android.app.Application
 import com.akaita.java.rxjava2debug.RxJava2Debug

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home.kt
@@ -3,41 +3,40 @@ package com.fortyseven.degrees.streamingapp
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
 
-
-sealed class HomeVM {
-    object Idle : HomeVM()
-    object Loading : HomeVM()
-    data class Full(val items: List<User>) : HomeVM()
-    data class Error(val t: Throwable) : HomeVM()
+sealed class HomeViewState {
+    object Idle : HomeViewState()
+    object Loading : HomeViewState()
+    data class Full(val items: List<User>) : HomeViewState()
+    data class Error(val t: Throwable) : HomeViewState()
 }
 
 // Our home program exist out of refreshing items on P2R & loading initial data
-fun HomeDependency.program(): Observable<Unit> =
+fun HomeDependencies.program(): Observable<Unit> =
     Observable.merge(refreshAccountsOnPull(), loadStartUpData())
 
-fun HomeDependency.refreshAccountsOnPull(): Observable<Unit> =
+fun HomeDependencies.refreshAccountsOnPull(): Observable<Unit> =
     pullToRefresh().switchMap {
         loadAccounts()
             .fork(Schedulers.io(), lifecycleVM)
             .void()
     }
 
-fun HomeDependency.loadAccounts(): Observable<Unit> =
-    post(HomeVM.Loading).flatMap {
-        loadAccountsFromDatabase().map(HomeVM::Full).flatMap { post(it) }
+fun HomeDependencies.loadAccounts(): Observable<Unit> =
+    post(HomeViewState.Loading).flatMap {
+        loadAccountsFromDatabase().map(HomeViewState::Full).flatMap { post(it) }
             .onErrorResumeNext { _: Throwable -> loadAccountsFromNetwork() }
             .switchIfEmpty(loadAccountsFromNetwork())
             .fork(Schedulers.io(), lifecycleVM)
             .void()
     }
 
-fun HomeDependency.loadAccountsFromNetwork(): Observable<Unit> =
-    fetchAccounts().map(HomeVM::Full)
+fun HomeDependencies.loadAccountsFromNetwork(): Observable<Unit> =
+    fetchAccounts().map(HomeViewState::Full)
         .flatMap { post(it) }
-        .onErrorResumeNext { t: Throwable -> post(HomeVM.Error(t)) }
+        .onErrorResumeNext { t: Throwable -> post(HomeViewState.Error(t)) }
 
 // Only load start-up data if empty
-fun HomeDependency.loadStartUpData(): Observable<Unit> =
+fun HomeDependencies.loadStartUpData(): Observable<Unit> =
     isEmpty().flatMap { isEmpty ->
         if (isEmpty) loadAccounts()
         else Observable.empty()

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home.kt
@@ -1,0 +1,44 @@
+package com.fortyseven.degrees.streamingapp
+
+import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
+
+
+sealed class HomeVM {
+    object Idle : HomeVM()
+    object Loading : HomeVM()
+    data class Full(val items: List<User>) : HomeVM()
+    data class Error(val t: Throwable) : HomeVM()
+}
+
+// Our home program exist out of refreshing items on P2R & loading initial data
+fun HomeDependency.program(): Observable<Unit> =
+    Observable.merge(refreshAccountsOnPull(), loadStartUpData())
+
+fun HomeDependency.refreshAccountsOnPull(): Observable<Unit> =
+    pullToRefresh().switchMap {
+        loadAccounts()
+            .fork(Schedulers.io(), lifecycleVM)
+            .void()
+    }
+
+fun HomeDependency.loadAccounts(): Observable<Unit> =
+    post(HomeVM.Loading).flatMap {
+        loadAccountsFromDatabase().map(HomeVM::Full).flatMap { post(it) }
+            .onErrorResumeNext { _: Throwable -> loadAccountsFromNetwork() }
+            .switchIfEmpty(loadAccountsFromNetwork())
+            .fork(Schedulers.io(), lifecycleVM)
+            .void()
+    }
+
+fun HomeDependency.loadAccountsFromNetwork(): Observable<Unit> =
+    fetchAccounts().map(HomeVM::Full)
+        .flatMap { post(it) }
+        .onErrorResumeNext { t: Throwable -> post(HomeVM.Error(t)) }
+
+// Only load start-up data if empty
+fun HomeDependency.loadStartUpData(): Observable<Unit> =
+    isEmpty().flatMap { isEmpty ->
+        if (isEmpty) loadAccounts()
+        else Observable.empty()
+    }

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home/HomeFragment.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home/HomeFragment.kt
@@ -17,7 +17,7 @@ import kotlinx.android.synthetic.main.fragment_home.view.*
 
 class HomeFragment : Fragment() {
 
-    private val viewModel = RxViewModel<HomeVM>(this, HomeVM.Idle)
+    private val viewModel = RxViewModel<HomeViewState>(this, HomeViewState.Idle)
     private val repo = MockRepository()
     private val persistence = MockPersistence()
 
@@ -39,7 +39,7 @@ class HomeFragment : Fragment() {
 
         Observable.merge(
             // Run business logic
-            HomeDependency.create(interactions, repo, persistence, viewModel)
+            HomeDependencies.create(interactions, repo, persistence, viewModel)
                 .program().subscribeOn(Schedulers.computation()),
 
             // Run view rendering
@@ -55,21 +55,21 @@ class HomeFragment : Fragment() {
     private fun render(
         view: View,
         adapter: UserAdapter,
-        state: HomeVM
+        state: HomeViewState
     ): Observable<Unit> =
         Observable.fromCallable {
             when (state) {
-                HomeVM.Idle -> {
+                HomeViewState.Idle -> {
                     view.pullToRefresh.isRefreshing = false
                 }
-                HomeVM.Loading -> {
+                HomeViewState.Loading -> {
                     view.pullToRefresh.isRefreshing = true
                 } // Use default loading ad
-                is HomeVM.Full -> {
+                is HomeViewState.Full -> {
                     view.pullToRefresh.isRefreshing = false
                     adapter.submitList(state.items)
                 }
-                is HomeVM.Error -> {
+                is HomeViewState.Error -> {
                     view.pullToRefresh.isRefreshing = false
                     Snackbar.make(view, getString(R.string.error, state.t), BaseTransientBottomBar.LENGTH_SHORT).show()
                 }

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home/HomeFragment.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home/HomeFragment.kt
@@ -5,10 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.AsyncDifferConfig
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
 import com.fortyseven.degrees.streamingapp.*
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
@@ -18,9 +14,6 @@ import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_home.view.*
-import kotlinx.android.synthetic.main.viewholder_user.view.*
-import memeid.UUID
-import java.util.concurrent.TimeUnit
 
 class HomeFragment : Fragment() {
 
@@ -82,126 +75,4 @@ class HomeFragment : Fragment() {
                 }
             }
         }
-}
-
-sealed class HomeVM {
-    object Idle : HomeVM()
-    object Loading : HomeVM()
-    data class Full(val items: List<User>) : HomeVM()
-    data class Error(val t: Throwable) : HomeVM()
-}
-
-interface HomeInteractions {
-    fun pullToRefresh(): Observable<Unit>
-}
-
-data class User(val id: UUID, val name: String) {
-    companion object
-}
-
-interface AccountRepo {
-    fun fetchAccounts(): Observable<List<User>>
-}
-
-fun MockRepository(accounts: Observable<List<User>>? = null) = object : AccountRepo {
-    override fun fetchAccounts(): Observable<List<User>> =
-        accounts ?: Observable.fromCallable {
-            listOf(
-                User(UUID.V4.squuid(), "Simon"),
-                User(UUID.V4.squuid(), "Raul"),
-                User(UUID.V4.squuid(), "Jorge")
-            )
-        }.delay(1300, TimeUnit.MILLISECONDS)
-}
-
-interface AccountPersistence {
-    fun loadAccountsFromDatabase(): Observable<List<User>>
-}
-
-fun MockPersistence(accounts: Observable<List<User>>? = null) = object : AccountPersistence {
-    override fun loadAccountsFromDatabase(): Observable<List<User>> =
-        accounts ?: Observable.fromCallable {
-            listOf(
-                User(UUID.V4.squuid(), "Simon"),
-                User(UUID.V4.squuid(), "Raul"),
-                User(UUID.V4.squuid(), "Jorge")
-            )
-        }.delay(700, TimeUnit.MILLISECONDS)
-}
-
-interface HomeDependency : HomeInteractions, AccountRepo, AccountPersistence, RxViewModel<HomeVM> {
-    companion object {
-        fun create(
-            interactions: HomeInteractions,
-            repo: AccountRepo,
-            persistence: AccountPersistence,
-            viewModel: RxViewModel<HomeVM>
-        ): HomeDependency = object : HomeDependency,
-            HomeInteractions by interactions,
-            AccountRepo by repo,
-            AccountPersistence by persistence,
-            RxViewModel<HomeVM> by viewModel {}
-    }
-}
-
-// Our home program exist out of refreshing items on P2R & loading initial data
-fun HomeDependency.program(): Observable<Unit> =
-    Observable.merge(refreshAccountsOnPull(), loadStartUpData())
-
-fun HomeDependency.refreshAccountsOnPull(): Observable<Unit> =
-    pullToRefresh().switchMap {
-        loadAccounts()
-            .fork(Schedulers.io(), lifecycleVM)
-            .void()
-    }
-
-fun HomeDependency.loadAccounts(): Observable<Unit> =
-    post(HomeVM.Loading).flatMap {
-        loadAccountsFromDatabase().map(HomeVM::Full).flatMap { post(it) }
-            .switchIfEmpty(loadAccountsFromNetwork())
-            .onErrorResumeNext { _: Throwable -> loadAccountsFromNetwork() }
-            .fork(Schedulers.io(), lifecycleVM)
-            .void()
-    }
-
-fun HomeDependency.loadAccountsFromNetwork(): Observable<Unit> =
-    fetchAccounts().map(HomeVM::Full)
-        .flatMap { post(it) }
-        .onErrorResumeNext { t: Throwable -> post(HomeVM.Error(t)) }
-
-// Only load start-up data if empty
-fun HomeDependency.loadStartUpData(): Observable<Unit> =
-    isEmpty().flatMap { isEmpty ->
-        if (isEmpty) loadAccounts()
-        else Observable.empty()
-    }
-
-// DiffUtil.ItemCallback is stateless thus can be object
-object UserDiffUtil : DiffUtil.ItemCallback<User>() {
-    override fun areItemsTheSame(oldItem: User, newItem: User): Boolean =
-        oldItem.id == newItem.id
-
-    override fun areContentsTheSame(oldItem: User, newItem: User): Boolean =
-        oldItem == newItem
-}
-
-val AsyncUserDiffUtil: AsyncDifferConfig<User> =
-    AsyncDifferConfig.Builder(UserDiffUtil).build()
-
-class UserAdapter : ListAdapter<User, UserViewHolder>(AsyncUserDiffUtil) {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder =
-        UserViewHolder(
-            LayoutInflater.from(parent.context)
-                .inflate(R.layout.viewholder_user, parent, false)
-        )
-
-    override fun onBindViewHolder(holder: UserViewHolder, position: Int) =
-        holder.bind(getItem(position))
-}
-
-class UserViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    fun bind(user: User): Unit {
-        itemView.user_id.text = user.id.toString()
-        itemView.user_name.text = user.name
-    }
 }

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home/adapter.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home/adapter.kt
@@ -1,0 +1,48 @@
+package com.fortyseven.degrees.streamingapp.home
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.AsyncDifferConfig
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.fortyseven.degrees.streamingapp.R
+import com.fortyseven.degrees.streamingapp.User
+import kotlinx.android.synthetic.main.viewholder_user.view.*
+
+// DiffUtil.ItemCallback is stateless thus can be object
+object UserDiffUtil : DiffUtil.ItemCallback<User>() {
+    override fun areItemsTheSame(oldItem: User, newItem: User): Boolean =
+        oldItem.id == newItem.id
+
+    override fun areContentsTheSame(oldItem: User, newItem: User): Boolean =
+        oldItem == newItem
+}
+
+val AsyncUserDiffUtil: AsyncDifferConfig<User> =
+    AsyncDifferConfig.Builder(UserDiffUtil).build()
+
+class UserAdapter : ListAdapter<User, UserViewHolder>(
+    AsyncUserDiffUtil
+) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder =
+        UserViewHolder(
+            LayoutInflater.from(parent.context)
+                .inflate(
+                    R.layout.viewholder_user,
+                    parent,
+                    false
+                )
+        )
+
+    override fun onBindViewHolder(holder: UserViewHolder, position: Int) =
+        holder.bind(getItem(position))
+}
+
+class UserViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    fun bind(user: User): Unit {
+        itemView.user_id.text = user.id.toString()
+        itemView.user_name.text = user.name
+    }
+}

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/interpreters.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/interpreters.kt
@@ -1,0 +1,30 @@
+package com.fortyseven.degrees.streamingapp
+
+import arrow.fx.typeclasses.milliseconds
+import io.reactivex.Observable
+import memeid.UUID
+import java.util.concurrent.TimeUnit
+
+fun MockRepository(accounts: Observable<List<User>>? = null) =
+    object : AccountRepo {
+        override fun fetchAccounts(): Observable<List<User>> =
+            accounts ?: Observable.fromCallable {
+                listOf(
+                    User(UUID.V4.squuid(), "Simon"),
+                    User(UUID.V4.squuid(), "Raul"),
+                    User(UUID.V4.squuid(), "Jorge")
+                )
+            }.delay(1300, TimeUnit.MILLISECONDS)
+    }
+
+fun MockPersistence(accounts: Observable<List<User>>? = null) =
+    object : AccountPersistence {
+        override fun loadAccountsFromDatabase(): Observable<List<User>> =
+            accounts ?: Observable.fromCallable {
+                listOf(
+                    User(UUID.V4.squuid(), "Simon"),
+                    User(UUID.V4.squuid(), "Raul"),
+                    User(UUID.V4.squuid(), "Jorge")
+                )
+            }.delay(700, TimeUnit.MILLISECONDS)
+    }

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/main/MainActivity.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/main/MainActivity.kt
@@ -1,7 +1,8 @@
-package com.fortyseven.degrees.streamingapp
+package com.fortyseven.degrees.streamingapp.main
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.fortyseven.degrees.streamingapp.R
 import com.fortyseven.degrees.streamingapp.home.HomeFragment
 
 class MainActivity : AppCompatActivity() {

--- a/StreamingAppDemo/app/src/test/java/com/fortyseven/degrees/streamingapp/HomeTest.kt
+++ b/StreamingAppDemo/app/src/test/java/com/fortyseven/degrees/streamingapp/HomeTest.kt
@@ -1,7 +1,6 @@
 package com.fortyseven.degrees.streamingapp
 
 import arrow.core.extensions.either.foldable.firstOrNone
-import com.fortyseven.degrees.streamingapp.home.*
 import io.reactivex.Observable
 import org.junit.Rule
 import org.junit.Test
@@ -16,9 +15,9 @@ class HomeTest {
 
     fun home(
         interactions: HomeInteractions,
-        viewModel: RxViewModel<HomeVM>
-    ): HomeDependency =
-        HomeDependency.create(
+        viewModel: RxViewModel<HomeViewState>
+    ): HomeDependencies =
+        HomeDependencies.create(
             interactions,
             MockRepository(),
             MockPersistence(Observable.empty()),
@@ -27,24 +26,24 @@ class HomeTest {
 
     @Test
     fun `Empty screen automatically refreshes data`() {
-        val empty = TestRxViewModel<HomeVM>(HomeVM.Idle)
+        val empty = TestRxViewModel<HomeViewState>(HomeViewState.Idle)
 
         home(empty_interactions, empty)
             .program()
             .flatMap { empty.state() }
             .test()
             .awaitCount(3)
-            .assertValueAt(0, HomeVM.Idle)
-            .assertValueAt(1, HomeVM.Loading)
-            .assertValueAt(2) { it is HomeVM.Full }
+            .assertValueAt(0, HomeViewState.Idle)
+            .assertValueAt(1, HomeViewState.Loading)
+            .assertValueAt(2) { it is HomeViewState.Full }
             .assertNotTerminated()
     }
 
     @Test
     fun `Loaded screen does nothing`() {
-        val empty = TestRxViewModel<HomeVM>(HomeVM.Idle)
+        val empty = TestRxViewModel<HomeViewState>(HomeViewState.Idle)
 
-        empty.post(HomeVM.Full(emptyList()))
+        empty.post(HomeViewState.Full(emptyList()))
             .flatMap {
                 parallelEither( // Run program & listen to state in parallel
                     home(empty_interactions, empty).program(),
@@ -53,8 +52,8 @@ class HomeTest {
             }
             .test()
             .awaitCount(2)
-            .assertValueAt(0, HomeVM.Idle)
-            .assertValueAt(1) { it is HomeVM.Full }
+            .assertValueAt(0, HomeViewState.Idle)
+            .assertValueAt(1) { it is HomeViewState.Full }
             .assertNotTerminated()
     }
 }

--- a/StreamingAppDemo/app/src/test/java/com/fortyseven/degrees/streamingapp/HomeTest.kt
+++ b/StreamingAppDemo/app/src/test/java/com/fortyseven/degrees/streamingapp/HomeTest.kt
@@ -46,7 +46,7 @@ class HomeTest {
 
         empty.post(HomeVM.Full(emptyList()))
             .flatMap {
-                eitherPar( // Run program & listen to state in parallel
+                parallelEither( // Run program & listen to state in parallel
                     home(empty_interactions, empty).program(),
                     empty.state()
                 ).filterMap { it.firstOrNone() } // Ignore program output


### PR DESCRIPTION
All code remains unchanged, except for a couple comments and the `RxSchedule` DSL.

- Interfaces were moved to `algebra`, and implementations to `interpreters`.
- Android code was moved into `main`, `home`, and `app`.
- `home` includes the home business logic -  decoupled from Android.
      => (Lifecycle / fork can be further abstracted to be even MPP compliant if desired)
