### PR TITLE
Retain state across configuration changes

### DIFF
--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home/HomeFragment.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/home/HomeFragment.kt
@@ -21,6 +21,11 @@ class HomeFragment : Fragment() {
     private val repo = MockRepository()
     private val persistence = MockPersistence()
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        retainInstance = true
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/main/MainActivity.kt
+++ b/StreamingAppDemo/app/src/main/java/com/fortyseven/degrees/streamingapp/main/MainActivity.kt
@@ -10,12 +10,11 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        showHome()
-    }
 
-    private fun showHome() {
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.fragmentContainer, HomeFragment())
-            .commit()
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.fragmentContainer, HomeFragment())
+                .commit()
+        }
     }
 }


### PR DESCRIPTION
- Only create the fragment when `savedInstanceState` is null (fresh start)
- set `retainInstance` to `true` so that the framework does not create a new fragment on config change